### PR TITLE
Feature - QuadTree Optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,53 @@
-# TombersAndPyramiders
-Play powerful parched pagan's pursuing prosperousness potentially peacefully.
+## Project Overview
+
+### Game
+
+Pyramid Panic is a 2.5D top down 16 person online ‘battle arena’ like game. Every player begins the game as an undead character with no weapons at the bottom of a pyramid. At the top of the pyramid is a treasure that brings your character back to life, but there is only one of these treasures and sixteen players. Players race to the top of the pyramid, solving puzzles, avoiding booby-traps and fighting other players along the way.
+
+The combat system allows for five types of equippable items. Weapons, Shields, Greaves, Helmets and Chestplates. Weapons, Shields and Greaves are activables, each with unique affects. The items equipped determines your characters fighting abilities. The pyramid is filled with other undead aggressive enemies that can kill players, as well as puzzle rooms which may require multiple characters to partake together. 
+
+### Engine
+
+The game engine is a custom built C++ engine created for both Windows and Mac. The engine uses SDL for the cross-platform audio, input, networking and window creation support, while using OpenGL to handle all rendering to the Window. The engine contains multiple features, such as sprite rendering, post-processing effects, culling, physics and collision detection, networking, messaging systems, and audio.
+
+### Current State
+
+The game is currently at our planned Alpha stage, which was intended to be our minimum viable product for user testing the controls and combat system over the network. Currently, the engine is built, however will require optimizations before beta. The game itself allows for two users to create a game online and fight each other. There are not currently any puzzles or randomly generated rooms, as those were planned for our beta version. Users can run around online, attacking each other with the bow they get on spawn. The players can switch to the sword that is on the ground to fight with the sword. There are random walking and shooting AI’s that are placed around the scene which can kill players or be killed.
+
+The game, however, is not complete. Not everything is sync’d over the network yet, meaning certain things get out of sync in the games. The game crashes on player death due to a bug with the networking logic, however that bug was deemed acceptable for the initial launch for testing due to player death already being the end game state for alpha. Optimizations are required to allow for mass scaling, currently the team is debating implementing quad tree’s to better handle the culling and physics collision. 
+
+User testing will be done to determine changes required for the core mechanics in the game before finalizing them for Beta.
+
+## Technology Stack
+
+The game and engine are both written in C++ 11. It is intended to be compilable on both the Microsoft VC++ compiler as well as with g++, therefore strictly C++ 11 compliant code is only allowed. On Windows, SDK version 10> is used with ToolKit version 141. The only external dependency used is SDL in order to give us convenient access to cross-platform networking, audio and input, as well as OpenGL 3.3 being used for rendering.
+
+### How To Compile - Windows
+- git clone
+- Open project in Visual Studio
+- Use ToolKit version 141 and SDK version 10
+- Build in x86
+- If errors occur regarding missing DLL's, copy the DLLs from the "RequiredRuntimeWindowsDLLs" folder into the built .exe's directory
+- If errors occur regarding failing to load assets, or if the screen is rendered in a pure colour such as red, create a "Game" folder in the directory that the .exe sits in, then copy the "Assets" folder into the new "Game" folder from the source code folder
+
+### How  To Run - Windows
+
+Once built, go to the directory the .exe sits in and run the executible by double clicking it.
+
+### Mac
+
+Alpha does not include Mac support. The engine does support Mac, however currently the game logic utilizes a very small amount of Microsoft specific code that is to be replaced before Beta. Mac support will be included in the future. 
+
+## Roadmap
+
+### Beta
+
+Our next milestone, our beta, will be created over the next month. The beta includes many upgrades, turning our concept into the intended game. The networking component will be upgraded to support sixteen players in a server based LAN environment where one player acts as the server. Audio assets will be added (created or royalty free) for varying types of scene music, as well as sound effects for every intractable noisy action. The combat system will be extended in breadth, creating various weapons in order to expand the possibilities for combat. This includes creating multiple weapons, shields, greaves, helmets and chestplates, many of which will require unique activatable abilities. The first four floors will be created for the pyramid, randomly generating rooms, with sand slowly filling up the pyramid, acting as a pseudo-timer to escape each room. All visual assets will have their initial pass created, however not necessarily finalized, for characters, weapons, armour, rooms and UI. Simple bloom post-processing effects will be added, as well as potential other shaders. The clearly defined win state of reaching the top of the pyramid first will be added in order to complete the desired game loop. The game will also be runnable on both Windows and Mac (and theoretically Linux, however we do not promise such compatibility).
+
+### Final
+
+The final milestone will be for April. This final release will include completing all the flours of the pyramid, randomly generating the floors, creating both puzzle rooms and combat rooms. The combat system will showcase various items with various effects. A full polished UI will be available for the game lobby and HUD. Post processing effects will be in full force with finalized visual art assets and sound, creating a polished feel. Most of the work going into final will be determine by user-testing from beta on how to improve the raw gameplay itself.
+
+## Team
+
+The team consists of seven members. The project manager, Dustin Limington, as well as eight other members, Carson Roscoe, Chen Li, Erick Fernandez de Arteaga, Evgeni Maiseyeu, Jaegar Sarauer, Kevin Han, Michael Nation, and Tanja Tong. We are all senior students completing our Bachelor of Technology in Computer Systems who came together to create an awesome game together.

--- a/TombersAndPyramiders/Engine/Component/Collision/Rigidbody.cpp
+++ b/TombersAndPyramiders/Engine/Component/Collision/Rigidbody.cpp
@@ -12,6 +12,10 @@ void Rigidbody::BlockMovement()
 		for (int i = 0; i < m_boxCollider->getColliders().size(); ++i)
 		{
 			GameObject* blockingGameObject = m_boxCollider->getColliders()[i];
+			if (blockingGameObject == nullptr || blockingGameObject == NULL) {
+				throw "RIGIDBODY::BLOCKMOVEMENT::NULL PTR FIX ME PLZ GUYS"; //TODO:: Michael & Evgeni:: Doesent get hit, blockingGameObject has garbage data and is not nullptr. getComponent crashes after this check fails
+				continue;
+			}
 			std::shared_ptr<BoxCollider> collider = blockingGameObject->getComponent<BoxCollider>();
 			if (!collider->isTrigger())
 			{

--- a/TombersAndPyramiders/Engine/Component/GameObject.h
+++ b/TombersAndPyramiders/Engine/Component/GameObject.h
@@ -12,7 +12,7 @@
 
 
 template<int> //template parameter could be anything!
-void dynamic_pointer_cast(); //ADD this. NO NEED TO DEFINE IT
+void dynamic_pointer_cast(); //ADD this. NO NEED TO DEFINE IT. Required for compiler due to some weird bug about not knowing which prototype is available in certain circumstances
 
 class GameObject : public Updateable
 {

--- a/TombersAndPyramiders/Engine/Component/Render/SpriteRenderer.cpp
+++ b/TombersAndPyramiders/Engine/Component/Render/SpriteRenderer.cpp
@@ -3,6 +3,7 @@
 
 SpriteRenderer::SpriteRenderer(GameObject* gameObject) : Renderer(gameObject)
 {
+
 	SpriteRendererManager::getInstance()->addSpriteForRendering(this); //.subscribe(gameObject.id, this); NOTE: Not subscribing/unsubscribing for now
 	m_activeShader = Shader::getShader();
 }
@@ -35,5 +36,5 @@ std::shared_ptr<ISprite> SpriteRenderer::getSprite()
 
 SpriteRenderer::~SpriteRenderer()
 {
-	SpriteRendererManager::getInstance()->removeSpriteFromRendering(this);
+	SpriteRendererManager::getInstance()->removeSpriteFromRendering(gameObject->getId());
 }

--- a/TombersAndPyramiders/Engine/Component/Render/SpriteRenderer.h
+++ b/TombersAndPyramiders/Engine/Component/Render/SpriteRenderer.h
@@ -6,7 +6,7 @@
 #include "ISprite.h"
 #include <memory>
 
-class SpriteRenderer : public Renderer
+class SpriteRenderer : public Renderer, public std::enable_shared_from_this<SpriteRenderer>
 {
 private:
 	GLuint m_textureBufferID;

--- a/TombersAndPyramiders/Engine/External/QuadTree.cpp
+++ b/TombersAndPyramiders/Engine/External/QuadTree.cpp
@@ -1,0 +1,244 @@
+#include "QuadTree.h"
+#include <iostream>
+#include <sstream>
+
+//## FOR USAGE EXPLENATION: See QuadTree.h ##
+
+//##QuadTree Implementations##
+QuadTree::QuadTree(QuadTreeBounds quadRect) : m_root(quadRect, 0) {}
+
+void QuadTree::lazyInsert(std::shared_ptr<GameObject> gameObject)
+{
+	m_lazyInserts.push_back(gameObject);
+}
+
+int QuadTree::reconstruct()
+{
+	int deletions = 0;
+	std::vector<std::shared_ptr<GameObject>> toReinsert;
+	//Restructures tree, populating toReinsert with objects not within their proper bounds
+	//and counts how many lazyDeletions have occured
+	m_root.reconstruct(toReinsert, deletions);
+	//Reinsert all objects that moved out of place
+	for (auto it = toReinsert.begin(); it != toReinsert.end(); it++)
+	{
+		if (*it != nullptr)
+		{
+			m_root.insert(*it);
+		}
+	}
+	//Insert all lazyInserts while we're already restructuring
+	for (int i = 0; i < m_lazyInserts.size(); i++)
+	{
+		if (m_lazyInserts[i] != nullptr)
+		{
+			m_root.insert(m_lazyInserts[i]);
+		}
+	}
+	m_lazyInserts.clear();
+
+	return deletions;
+}
+
+QuadTreeBounds QuadTree::getBounds()
+{
+	return m_root.m_bounds;
+}
+
+void QuadTree::insert(std::shared_ptr<GameObject> gameObject)
+{
+	m_root.insert(gameObject);
+}
+
+void QuadTree::populateList(QuadTreeBounds & bounds, std::vector<std::shared_ptr<GameObject>> &gameObjects)
+{
+	m_root.populate(bounds, gameObjects);
+}
+
+std::set<std::shared_ptr<GameObject>> QuadTree::getAll()
+{
+	std::set<std::shared_ptr<GameObject>> toReturn;
+	m_root.getAll(toReturn);
+	return toReturn;
+}
+
+bool QuadTree::intersects(QuadTreeBounds &quadBounds1, QuadTreeBounds &quadBounds2)
+{
+	return !(
+		quadBounds1.getX() + quadBounds1.getWidth() / 2.0f < quadBounds2.getX() - quadBounds2.getWidth() / 2.0f ||
+		quadBounds1.getX() - quadBounds1.getWidth() / 2.0f > quadBounds2.getX() + quadBounds2.getWidth() / 2.0f ||
+		quadBounds1.getY() - quadBounds1.getHeight() / 2.0f > quadBounds2.getY() + quadBounds2.getHeight() / 2.0f ||
+		quadBounds1.getY() + quadBounds1.getWidth() / 2.0f < quadBounds2.getY() - quadBounds2.getHeight() / 2.0f
+		);
+}
+
+//##QuadTreeBounds Implementations##
+QuadTreeBounds::QuadTreeBounds(float x, float y, float width, float height)
+{
+	m_x = x;
+	m_y = y;
+	m_width = width;
+	m_height = height;
+}
+QuadTreeBounds::QuadTreeBounds(std::shared_ptr<GameObject> gameObject)
+{
+	if (gameObject != nullptr)
+	{
+		m_x = gameObject->getTransform()->getX();
+		m_y = gameObject->getTransform()->getY();
+		m_width = gameObject->getTransform()->getScale();
+		m_height = gameObject->getTransform()->getScale();
+	}
+	else
+	{
+		throw "ERROR::QuadTreeBounds(std::shared_ptr<GameObject> gameObject)::GameObject given was nullptr";
+	}
+}
+
+float QuadTreeBounds::getX() { return m_x; }
+float QuadTreeBounds::getY() { return m_y; }
+float QuadTreeBounds::getWidth() { return m_width; }
+float QuadTreeBounds::getHeight() { return m_height; }
+
+
+//##QuadTreeNode Implementations
+QuadTree::Node::Node(QuadTreeBounds &_bounds, int pLevel) : m_bounds(_bounds), m_depth(++pLevel) {}
+
+bool QuadTree::Node::isLeaf()
+{
+	return m_children[0] == nullptr;
+}
+
+void QuadTree::Node::split()
+{
+	//Create a child for each quadrant
+	float newWidth = m_bounds.getWidth() / 2.0f;
+	float newHeight = m_bounds.getHeight() / 2.0f;
+
+	//TopLeft
+	m_children[0].reset(new Node(QuadTreeBounds(m_bounds.getX() - newWidth / 2.0f, m_bounds.getY() + newHeight / 2.0f, newWidth, newHeight), m_depth));
+	//TopRight
+	m_children[1].reset(new Node(QuadTreeBounds(m_bounds.getX() + newWidth / 2.0f, m_bounds.getY() + newHeight / 2.0f, newWidth, newHeight), m_depth));
+	//BottomLeft
+	m_children[2].reset(new Node(QuadTreeBounds(m_bounds.getX() - newWidth / 2.0f, m_bounds.getY() - newHeight / 2.0f, newWidth, newHeight), m_depth));
+	//BottomRight
+	m_children[3].reset(new Node(QuadTreeBounds(m_bounds.getX() + newWidth / 2.0f, m_bounds.getY() - newHeight / 2.0f, newWidth, newHeight), m_depth));
+	
+	//Insert items into children
+	for (int j = 0; j < m_items.size(); j++)
+	{
+		std::shared_ptr<GameObject> object = m_items[j];
+		for (int i = 0; i < 4; i++)
+		{
+			if (object != nullptr)
+			{
+				m_children[i]->insert(object);
+			}
+		}
+	}
+
+	//Clear item collection
+	m_items.clear();
+}
+
+void QuadTree::Node::populate(QuadTreeBounds& bounds, std::vector<std::shared_ptr<GameObject>> &retItems)
+{
+	if (!intersects(m_bounds, bounds))
+	{
+		return; //Not in bounds, don't perform population
+	}
+
+	if (isLeaf())
+	{
+		for (int i = 0; i < m_items.size(); i++)
+		{
+			if (m_items[i] != nullptr)
+			{
+				retItems.push_back(m_items[i]);
+			}
+			
+		}
+	}
+	else
+	{
+		for (auto &child : m_children)
+		{
+			child->populate(bounds, retItems); //Populate from children
+		}
+	}
+}
+
+void QuadTree::Node::insert(std::shared_ptr<GameObject> item)
+{
+	if (!intersects(m_bounds, QuadTreeBounds(item)))
+	{
+		return; //Not in bounds, don't insert
+	}
+
+	if (isLeaf() && m_items.size() == m_maxItems && m_depth < m_maxDepth)
+	{
+		split(); //Too full and more depth to go, so split
+	}
+
+	if (isLeaf())
+	{
+		m_items.push_back(item); //Leaf node, directly add to item collection. If items is bigger than max size before split, it'll keep growing since we're at max depth
+	}
+	else
+	{
+		for (auto &child : m_children)
+		{
+			child->insert(item); //Attempt to insert into children
+		}
+	}
+}
+
+void QuadTree::Node::reconstruct(std::vector<std::shared_ptr<GameObject>> &gameObjects, int& deletions)
+{
+	if (isLeaf())
+	{
+		for (int i = 0; i < m_items.size(); i++)
+		{
+			if (m_items[i] != nullptr)
+			{
+				if (!intersects(m_bounds, QuadTreeBounds(m_items[i])))
+				{
+					gameObjects.push_back(m_items[i]);
+					deletions++;
+					m_items[i] = nullptr; //Lazy deletion. Will be removed on split, skipped on populate
+				}
+			}
+			else {
+				deletions++;
+			}
+		}
+	}
+	else {
+		for (int i = 0; i < 4; i++)
+		{
+			m_children[i]->reconstruct(gameObjects, deletions);
+		}
+	}
+}
+
+void QuadTree::Node::getAll(std::set<std::shared_ptr<GameObject>> &gameObjects)
+{
+	if (isLeaf())
+	{
+		for (int i = 0; i < m_items.size(); i++)
+		{
+			if (m_items[i] != nullptr)
+			{
+				gameObjects.insert(m_items[i]);
+			}
+		}
+	}
+	else 
+	{
+		for (int i = 0; i < 4; i++)
+		{
+			m_children[i]->getAll(gameObjects);
+		}
+	}
+}
+

--- a/TombersAndPyramiders/Engine/External/QuadTree.h
+++ b/TombersAndPyramiders/Engine/External/QuadTree.h
@@ -1,0 +1,99 @@
+#pragma once
+
+/*
+	##CLASSES##
+
+	QuadTree	
+		- Constructed with a QuadTreeBounds which represents the total bounds of the world
+		- Used for fast culling of GameObjects
+
+	QuadTreeBounds:
+		- Represents the x/y/width/height boundaries of QuadTrees
+		- Can be constructed with GameObject's or raw x/y/width/height
+
+	##PUBLIC METHODS##
+
+	QuadTree
+		QuadTree(QuadTreeBounds quadRect)
+		void insert(std::shared_ptr<GameObject> gameObject)
+		void lazyInsert(std::shared_ptr<GameObject> gameObject)
+		void populateList(QuadTreeBounds & bounds, std::vector<std::shared_ptr<GameObject>> &gameObjects)
+		int reconstruct()
+		QuadTreeBounds getBounds()
+		std::set<std::shared_ptr<GameObject>> getAll()
+*/
+
+#include <vector>
+#include <memory>
+#include "GameObject.h"
+#include <set>
+
+//QuadTree Boundaries used for representing x/y/width/height collision boundaries
+struct QuadTreeBounds
+{
+private:
+	float m_x;
+	float m_y;
+	float m_width;
+	float m_height;
+public:
+	QuadTreeBounds(float x, float y, float width, float height);
+	QuadTreeBounds(std::shared_ptr<GameObject> gameObject);
+	float getX();
+	float getY();
+	float getWidth();
+	float getHeight();
+};
+
+//QuadTree implementation used for culling
+class QuadTree
+{
+private:
+	//Maximum number of Items a node can hold until splitting
+	static const int m_maxItems = 10;
+	//Maximum depth of the quadTree
+	static const int m_maxDepth = 4; 
+
+	//Bounding box intersection
+	static bool intersects(QuadTreeBounds &quadBounds1, QuadTreeBounds &quadBounds2);
+
+	//Node constituting tree structure
+	struct Node
+	{
+	public:
+		QuadTreeBounds m_bounds; //physical bounds of node
+		const int m_depth; //depth
+
+		std::unique_ptr<Node> m_children[4]; //child nodes
+		std::vector<std::shared_ptr<GameObject>> m_items; //collection of retItems
+
+		Node(QuadTreeBounds &_bounds, int pLevel);
+
+		bool isLeaf();
+		void split();
+		void populate(QuadTreeBounds& bounds, std::vector<std::shared_ptr<GameObject>> &retItems);
+		void insert(std::shared_ptr<GameObject> item);
+		void reconstruct(std::vector<std::shared_ptr<GameObject>> &gameObjects, int& deletions);
+		void getAll(std::set<std::shared_ptr<GameObject>> &gameObjects);
+	};
+
+	Node m_root;
+
+	//Objects to insert lazily on next tree reconstructions
+	std::vector<std::shared_ptr<GameObject>> m_lazyInserts;
+
+public:
+	QuadTree(QuadTreeBounds quadRect);
+	//Immediate insertion into QuadTree
+	void insert(std::shared_ptr<GameObject> gameObject);
+	//Delayed insertions to be invoked on reconstruction
+	void lazyInsert(std::shared_ptr<GameObject> gameObject);
+	//Given the QuadTreeBounds, populates the gameObjects vector with all game objects within the bounds
+	void populateList(QuadTreeBounds & bounds, std::vector<std::shared_ptr<GameObject>> &gameObjects);
+	//Reorganizes the tree, updating moved objects and handling lazy deletion/lazy insertion
+	int reconstruct();
+	//Returns the QuadTreeBounds of the root node
+	QuadTreeBounds getBounds();
+	//Returns all of the gameObjects found within the QuadTree
+	std::set<std::shared_ptr<GameObject>> getAll();
+};

--- a/TombersAndPyramiders/Engine/Manager/GameManager.h
+++ b/TombersAndPyramiders/Engine/Manager/GameManager.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include "Scene.h"
 #include "SceneManager.h"
+#include "QuadTree.h"
 
 class GameManager : public Updateable
 {
@@ -21,6 +22,9 @@ public:
 	static GameManager* getInstance();
 	void addGameObject(int id, std::shared_ptr<GameObject> obj);
 	void removeGameObject(int objectToRemove);
+	std::vector<std::shared_ptr<GameObject>> getObjectsInBounds(float x, float y, float width, float height);
+	void updateQuadTree();
+
 	template <typename T, class... _Types>
 	std::shared_ptr<T> createGameObject(bool isGlobal, _Types&&... args)
 	{
@@ -41,6 +45,7 @@ public:
 			{
 				SceneManager::getInstance()->getCurrentScene()->addGameObject(id, gameObject);
 			}
+			m_quadTree->lazyInsert(gameObject);
 		} 
 		else 
 		{
@@ -68,6 +73,7 @@ public:
 			{
 				SceneManager::getInstance()->getCurrentScene()->addGameObject(id, gameObject);
 			}
+			m_quadTree->lazyInsert(gameObject);
 		}
 		else
 		{
@@ -80,10 +86,14 @@ public:
 private:
 	std::vector<int> m_gameObjectsToRemove;
 	std::map<int, std::shared_ptr<GameObject>> m_globalGameObjects;
+	std::unique_ptr<QuadTree> m_quadTree = nullptr;
+
 	static GameManager* s_instance;
 	bool m_breakLoop = false;
 	int m_lastTime = 0;
 	//game instance.
 	Game* m_game;
 	void fpsThrottle(int ticks);
+	void reinstantiateQuadTree(float x, float y, float width, float height); 
+	void resizeQuadTree(float x, float y, float width, float height);
 };

--- a/TombersAndPyramiders/Engine/Manager/SpriteRendererManager.cpp
+++ b/TombersAndPyramiders/Engine/Manager/SpriteRendererManager.cpp
@@ -4,6 +4,7 @@
 #include <condition_variable>
 #include "SpriteSheet.h"
 #include "Camera.h"
+#include "GameManager.h"
 
 /*
 TODO:
@@ -37,6 +38,15 @@ spriteRenderers.erase(id);
 
 void SpriteRendererManager::onUpdate(int ticks)
 {
+	for (int i = 0; i < m_spritesToSubscribe.size(); i++) 
+	{
+		if (m_spritesToSubscribe[i] != nullptr)
+		{
+			m_activeSprites[m_spritesToSubscribe[i]->getGameObject()->getId()] = m_spritesToSubscribe[i]->shared_from_this();
+		}
+	}
+	m_spritesToSubscribe.clear();
+
 	prepareRenderingThread();
 	//Load fboPlainPass
 	//renderReadingStick.lock();
@@ -257,78 +267,100 @@ GLuint SpriteRendererManager::generateTexture(std::string textureFileName)
 }
 
 
-bool sortByZ(SpriteRenderer *lhs, SpriteRenderer *rhs)
+bool sortByZ(std::shared_ptr<SpriteRenderer> lhs, std::shared_ptr<SpriteRenderer> rhs)
 {
 	return lhs->getGameObject()->getTransform()->getZ() < rhs->getGameObject()->getTransform()->getZ();
 }
 
 void SpriteRendererManager::prepareRenderingThread()
 {
-	GLuint lastShaderUnset = 1000000;
-
-	//while (isBeingCollected);
-	//std::unique_lock<std::mutex> lock(threadMutex);
-
-	//while (renderingThreadIsAlive)
-	//{
-		//condition.wait(lock);
-		//renderReadingStick.lock();
-	m_renderingGroups.clear();
-	GLuint lastShader = lastShaderUnset;
-	std::sort(m_activeSprites.begin(), m_activeSprites.end(), sortByZ);
-	RenderingShaderGroup rg;
-
 	if (m_activeSprites.size() > 0)
 	{
+		GLuint lastShaderUnset = 1000000;
+
+		//while (isBeingCollected);
+		//std::unique_lock<std::mutex> lock(threadMutex);
+
+		//while (renderingThreadIsAlive)
+		//{
+		//condition.wait(lock);
+		//renderReadingStick.lock();
+		m_renderingGroups.clear();
+		GLuint lastShader = lastShaderUnset;
+		RenderingShaderGroup rg;
+
 		std::shared_ptr<Camera> camera = Camera::getActiveCamera();
-		for (size_t i = 0; i < m_activeSprites.size(); i++)
+
+		std::vector<std::shared_ptr<SpriteRenderer>> renderers;
+		int toRender = 0;
+
+		//##Have Culled Objects. Find Ones To Render
+		auto objectsInBounds = GameManager::getInstance()->getObjectsInBounds(camera->getTransform()->getX(), camera->getTransform()->getY(), getGameWidth(), getGameHeight());
+		for (size_t i = 0; i < objectsInBounds.size(); i++)
 		{
-			SpriteRenderer *spriteRenderer = m_activeSprites[i];
+			if (objectsInBounds[i] == nullptr || objectsInBounds[i] == NULL)
+			{
+				continue;
+			}
+			if (m_activeSprites.find(objectsInBounds[i]->getId()) == m_activeSprites.end())
+			{
+				continue; //This game object is not one we're supposed to render either way
+			}
+			std::shared_ptr<SpriteRenderer> spriteRenderer = m_activeSprites[objectsInBounds[i]->getId()]; //objectsInBounds[i]->getComponent<SpriteRenderer>() also misculls so it is the getObjectsInBounds call itself
+			if (spriteRenderer == nullptr)
+			{
+				continue;
+			}
+			renderers.push_back(spriteRenderer);
+		}
+
+		//##Have Renderers. Sort Them
+		std::sort(renderers.begin(), renderers.end(), sortByZ);
+
+		//##Have Sorted Renderers. Prepare Rendering Info Objects
+		for (size_t i = 0; i < renderers.size(); i++) {
+			std::shared_ptr<SpriteRenderer> spriteRenderer = renderers[i];
+
 			Transform* transform = spriteRenderer->getGameObject()->getTransform();
 			
-			if (camera->isOnScreen(transform)) 
+			RenderingObject ro;
+
+			Shader *shader = spriteRenderer->getShader();
+			if (shader == nullptr)
 			{
-				RenderingObject ro;
-
-				Shader *shader = spriteRenderer->getShader();
-				if (shader == nullptr)
-				{
-					continue;
-				}
-				GLuint roShader = shader->program;
-				ro.sprite = spriteRenderer->getSprite();
-
-				if (lastShader == lastShaderUnset)
-				{
-					lastShader = roShader;
-					rg.shaderProgram = roShader;
-					rg.shaderID = shader->getID();
-				}
-
-				if (roShader != lastShader)
-				{
-					m_renderingGroups.push_back(rg);
-					lastShader = roShader;
-					rg = RenderingShaderGroup();
-					rg.shaderProgram = roShader;
-					rg.shaderID = shader->getID();
-				}
-
-				//Pass in transform
-				ro.transform = transform;
-
-				ro.spriteRenderer = spriteRenderer;
-
-				if (ro.isValid())
-				{
-					rg.children.push_back(ro);
-				}
+				continue;
 			}
-			//if (isRenderingLayerEnabled(spriteRenderer->getLayer()))
-			//{
-				
-			//}
+			GLuint roShader = shader->program;
+			ro.sprite = spriteRenderer->getSprite();
+
+			if (lastShader == lastShaderUnset)
+			{
+				lastShader = roShader;
+				rg.shaderProgram = roShader;
+				rg.shaderID = shader->getID();
+			}
+
+			if (roShader != lastShader)
+			{
+				m_renderingGroups.push_back(rg);
+				lastShader = roShader;
+				rg = RenderingShaderGroup();
+				rg.shaderProgram = roShader;
+				rg.shaderID = shader->getID();
+			}
+
+			//Pass in transform
+			ro.transform = transform;
+
+			ro.spriteRenderer = spriteRenderer;
+
+			if (ro.isValid())
+			{
+				rg.children.push_back(ro);
+				toRender++;
+			}
 		}
+		std::cout << objectsInBounds.size() << " " << toRender << std::endl;
 		m_renderingGroups.push_back(rg);
 	}
 
@@ -474,6 +506,9 @@ void SpriteRendererManager::renderPass(int layerToRender, bool clearFirst)
 						int hit = 0;
 					}
 					glUniform3i(spriteSheetLocation, spriteSheet->getColumnCount(), spriteSheet->getRowCount(), spriteSheet->getCurrentIndex());
+				}
+				else {
+					int hit = 1;
 				}
 			}
 
@@ -640,9 +675,12 @@ void SpriteRendererManager::applyEndProcessing(FrameBufferObject mainTexture, Fr
 	//Draw mainTexture with postProcessingOverlay overlayed
 }
 
-void SpriteRendererManager::addSpriteForRendering(SpriteRenderer *sprite)
+void SpriteRendererManager::addSpriteForRendering(SpriteRenderer* sprite)
 {
-	m_activeSprites.push_back(sprite);
+	if (sprite != nullptr)
+	{
+		m_spritesToSubscribe.push_back(sprite); //Have to lazy load it into a spritesToAdd list because sprite->getGameObject->getId() is not set when SpriteRenderer's constructor is called
+	}
 }
 
 void SpriteRendererManager::disableRenderingLayer(int layer)
@@ -665,9 +703,9 @@ bool SpriteRendererManager::isRenderingLayerEnabled(int layer)
 	return m_disabledLayers.find(layer) == m_disabledLayers.end();
 }
 
-void SpriteRendererManager::removeSpriteFromRendering(SpriteRenderer *sprite)
+void SpriteRendererManager::removeSpriteFromRendering(int objectID)
 {
-	m_activeSprites.erase(std::remove(m_activeSprites.begin(), m_activeSprites.end(), sprite), m_activeSprites.end());
+	m_activeSprites[objectID] = nullptr;
 }
 
 void SpriteRendererManager::purge()

--- a/TombersAndPyramiders/Engine/Manager/SpriteRendererManager.h
+++ b/TombersAndPyramiders/Engine/Manager/SpriteRendererManager.h
@@ -17,6 +17,7 @@
 #include "FrameBufferObject.h"
 #include "UserDefinedRenderLayers.h"
 #include <memory>
+#include <map>
 
 #define SHADER_TYPE_DEFAULT 0
 #define SHADER_TYPE_PIXEL 1
@@ -26,7 +27,7 @@ struct RenderingObject
 {
 	std::shared_ptr<ISprite> sprite;
 	Transform* transform;
-	SpriteRenderer* spriteRenderer;
+	std::shared_ptr<SpriteRenderer> spriteRenderer;
 
 	bool isValid()
 	{
@@ -59,7 +60,8 @@ class SpriteRendererManager
 private:
 	//Singleton variables
 	static SpriteRendererManager *s_instance;
-	std::vector<SpriteRenderer*> m_activeSprites;
+	std::map<int, std::shared_ptr<SpriteRenderer>> m_activeSprites;
+	std::vector<SpriteRenderer*> m_spritesToSubscribe;
 	std::unordered_set<int> m_disabledLayers;
 	std::thread m_renderingThread;
 	std::mutex m_renderTalkingStick;
@@ -103,12 +105,12 @@ public:
 	void enableRenderingLayer(int layer);
 	void enableAllRenderingLayers();
 	bool isRenderingLayerEnabled(int layer);
-	void removeSpriteFromRendering(SpriteRenderer* sprite);
+	void removeSpriteFromRendering(int objectID);
 	void purge();
 
 	/////RENDERING METHODS: Maybe extract to a base "RenderContext" class to pass to the Camera
 	void renderShadowPass(float xSourceDirection, float ySourceDirection, float shadowStrength);
-	void renderPass(int layer = RENDER_LAYER_ALL, bool clearFirst = true);
+	void renderPass(int layer = 0, bool clearFirst = true);
 	void renderFBO(FrameBufferObject fboToRender, Shader* shader, FrameBufferObject* toFbo = nullptr); //Default "FBOShader" type assumes it takes a texture to draw
 
 	void renderGaussianBlur(FrameBufferObject fboToBlur, FrameBufferObject* toFbo = nullptr); //Blurs then draws

--- a/TombersAndPyramiders/Game/Game.cpp
+++ b/TombersAndPyramiders/Game/Game.cpp
@@ -5,6 +5,7 @@
 #include <iostream>
 #include "CharacterTestScene.h"
 #include "LaunchScene.h"
+#include "NetworkedGameScene.h"
 
 /*
 This class is not intended to have a lot of code. This is intended to be the on entry call for
@@ -20,7 +21,7 @@ Each GameObject cycles through and updates each one of their game components.
 
 void Game::onStart()
 {
-	SceneManager::getInstance()->pushScene(new LaunchScene());
+	SceneManager::getInstance()->pushScene(new LaunchScene());//NetworkedGameScene());
 }
 
 void Game::onUpdate(int ticks)

--- a/TombersAndPyramiders/Game/Scenes/NetworkedGameScene.cpp
+++ b/TombersAndPyramiders/Game/Scenes/NetworkedGameScene.cpp
@@ -36,7 +36,6 @@ void NetworkedGameScene::onStart()
 
 	SpawnManager::getInstance()->generateMiscSquare(25, -25, -100, 115, "sandBG.png", false);
 
-
 	for (float x = 0; x <= size; x++)
 	{
 		for (float y = 0; y >= -size; y--)

--- a/TombersAndPyramiders/TombersAndPyramiders.vcxproj
+++ b/TombersAndPyramiders/TombersAndPyramiders.vcxproj
@@ -141,6 +141,7 @@
     <ClCompile Include="Engine\Component\Collision\Rigidbody.cpp" />
     <ClCompile Include="Engine\Component\Networking\Receiver.cpp" />
     <ClCompile Include="Engine\Component\Networking\Sender.cpp" />
+    <ClCompile Include="Engine\External\QuadTree.cpp" />
     <ClCompile Include="Engine\External\Render\FrameBufferObject.cpp" />
     <ClCompile Include="Engine\External\Render\ISprite.cpp" />
     <ClCompile Include="Engine\External\Render\Sprite.cpp" />
@@ -230,6 +231,7 @@
     <ClInclude Include="Engine\Component\Collision\Rigidbody.h" />
     <ClInclude Include="Engine\Component\Networking\Receiver.h" />
     <ClInclude Include="Engine\Component\Networking\Sender.h" />
+    <ClInclude Include="Engine\External\QuadTree.h" />
     <ClInclude Include="Engine\External\Render\FrameBufferObject.h" />
     <ClInclude Include="Engine\External\Render\ISprite.h" />
     <ClInclude Include="Engine\External\Render\Sprite.h" />

--- a/TombersAndPyramiders/TombersAndPyramiders.vcxproj.filters
+++ b/TombersAndPyramiders/TombersAndPyramiders.vcxproj.filters
@@ -88,6 +88,7 @@
     <ClCompile Include="Paper.cpp" />
     <ClCompile Include="PathFinding.cpp" />
     <ClCompile Include="Game\Scenes\LaunchScene.cpp" />
+    <ClCompile Include="Engine\External\QuadTree.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Engine\Component\AI\AI.h" />
@@ -184,6 +185,7 @@
     <ClInclude Include="PathFinding.h" />
     <ClInclude Include="SearchCell.h" />
     <ClInclude Include="Game\Scenes\LaunchScene.h" />
+    <ClInclude Include="Engine\External\QuadTree.h" />
   </ItemGroup>
   <ItemGroup>
     <Image Include="Assets\Character.bmp" />

--- a/TombersAndPyramiders/main.cpp
+++ b/TombersAndPyramiders/main.cpp
@@ -15,11 +15,11 @@ void RunGame();
 int main(int argc, char *argv[])
 {
 	//For Visual Studio std::cout outputs
-/*#if defined _WIN32 || defined _WIN64
+#if defined _WIN32 || defined _WIN64
 	AllocConsole();
 	freopen("CONOUT$", "w", stdout);
 	freopen("CONOUT$", "w", stderr);
-#endif*/
+#endif
 
   //AudioManager audioManager;
   //audioManager.PlaySoundEffect("mario_.mp3");


### PR DESCRIPTION
**Non-QuadTree Code**

This pull request includes some non-QuadTree stuff, such as an updated README and renaming the GitHub repository to PyramidPanic.

-----

### Bottleneck

Profiling the project showcased two major bottlenecks when attempting to have the project scale. These two bottlenecks were the rendering loop and the physics loop. Both of these required iterating over every game object in the world and doing comparisons regarding the position of the object relative to others (with Rendering determining what to draw, and the PhysicsManager checking for collisions).
Solution

Both of these bottlenecks can be reduced if a lower time complexity solution was present for determining whether objects are reasonably close to one other. QuadTree's are an excellent complicated data structure which solves this particular niche very well, reducing the time complexity of object bounding look ups.

### Implementation Details

This specific QuadTree implementation takes advantage of STL smart pointers. It also does not rely on treating objects as x/y points, and can instead treat them themselves as bounds. Objects straddling the bounds between quads are placed in both nodes, however lookup utilizes Sets to avoid duplicates.

### Notes

SpriteRendererManager takes advantage of the QuadTree for culling, and replaced the Camera::isOnScreen technique that was used previously in the projects Alpha. Replacing Camera::isOnScreen with the QuadTree reduced the rendering loop heavily, as previously every object still had to be iterated over and checked whether it was culled individually, whereas now the QuadTree inherently omits culled objects entirely.

The profiler showed using Camera::isOnScreen for culling results in the SpriteRendererManager (when playing with 300 game objects) used slightly over 40% of the games CPU, however using the QuadTree instead, this amount is reduced to 24%, with a 6% increase in overhead regarding maintaining the QuadTree.

When increasing the amount of (Collider-less) game objects into the thousands, the SpriteRendererManager was using roughly 70% CPU usage with Camera::isOnScreen, however only 30%ish with the QuadTree, showcasing a vast improvement on scalability.